### PR TITLE
add KaTeX support

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -5,6 +5,7 @@ const withNextra = require('nextra')({
     codeblocks: false,
   },
   defaultShowCopyCode: true,
+  latex: true,
 })
 
 module.exports = withNextra()

--- a/pages/about-v2/keeper-incentives.mdx
+++ b/pages/about-v2/keeper-incentives.mdx
@@ -8,13 +8,17 @@ For matching orders, Keepers receive a portion of the taker fee.
 
 For cancelling orders (that can be cancelled see [**Advanced Orders FAQ**](/trading/advanced-orders-faq)), Keepers will receive the `cancel_order_fee` on the state.
 
-Currently, the USDC reward function for keepers (_f_keeper_) is designed as:
+Currently, the USDC reward function for keepers ($f_{\text{keeper}}$) is designed as:
 
-![](https://archbee.imgix.net/ps_9Ff-LBbQB7IaXI3f3F/7X0tYmUqT218-A0gfXSz-_image.png)
+$
+f_{\text{keeper}} = \textit{min}(0.01 \ast 
+\textit{max}\left(1, t_{\text{order}}\right)^
+{1/4}, 0.1 \ast f_{\text{user}})
+$
 
 where:
-_t_order_ is seconds since the order was placed
-_f_user_ is the taker fee paid by the user who placed the order
+$t_{\text{order}}$ is seconds since the order was placed
+$f_{\text{user}}$ is the taker fee paid by the user who placed the order
 
 This reward is subject to evolve to incentivise CLOB-like execution ordering. See [**source code**](https://github.com/drift-labs/protocol-v1/blob/c748c64fcfa6d7fd5aba72f7021218dd6aaa02f0/programs/clearing_house/src/math/fees.rs#L257) for the on-chain calculation.
 
@@ -25,4 +29,3 @@ A Keeper reward multiplier (for taker price improvement) is applied to the keepe
 ### Future Work
 
 30d fill volume for keepers is tracked on-chain via `UserStats`, allowing for logic to reward consistent keepers with a larger multiplier on rewards.
-


### PR DESCRIPTION
Added KaTeX support (see [reference](https://nextra.site/docs/guide/advanced/latex)) so that we don't have to use a pixelated image of the math eqn.

**After my changes**
<img width="835" alt="image" src="https://github.com/drift-labs/drift-docs-v2/assets/8350076/7654f350-7c73-414d-b70c-4bf124da4d73">
